### PR TITLE
Added support for verifying the ParamName of ArgumentExceptions.

### DIFF
--- a/src/should.Facts/ActionAssertionExtension_Facts.cs
+++ b/src/should.Facts/ActionAssertionExtension_Facts.cs
@@ -7,7 +7,7 @@ namespace Should.Facts
     {
         private static object ThrowMethod()
         {
-            throw new ArgumentException();
+            throw new ArgumentException("Bad value.", "badParamName");
         }
 
         [Fact]
@@ -24,6 +24,22 @@ namespace Should.Facts
             Assert.Throws(
                 typeof(Should.Core.Exceptions.ThrowsException),
                 () => action.ShouldThrow<ApplicationException>());
+        }
+
+        [Fact]
+        public void ShouldThrow_passes_if_ArgumentException_parameter_name_matches()
+        {
+            Action action = () => ThrowMethod();
+            action.ShouldThrow<ArgumentException>("badParamName");
+        }
+
+        [Fact]
+        public void ShouldThrow_fails_if_ArgumentException_parameter_name_does_not_match()
+        {
+            Action action = () => ThrowMethod();
+            Assert.Throws(
+                typeof(Should.Core.Exceptions.EqualException),
+                () => action.ShouldThrow<ArgumentException>("differentParamName"));
         }
     }
 }

--- a/src/should/ActionAssertionExtensions.cs
+++ b/src/should/ActionAssertionExtensions.cs
@@ -13,12 +13,36 @@ namespace Should
             ShouldThrow<T>(new Assert.ThrowsDelegate(action));
         }
 
+        /// <summary>
+        /// Verifies that the <paramref name="@delegate"/> throws an <see cref="ArgumentException"/> with a <paramref name="paramName"/> that matches <see cref="ArgumentException.ParamName"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="ArgumentException"/> expected to be thrown.</typeparam>
+        /// <param name="action">The action which should throw the exception.</param>
+        /// <param name="paramName">The name of the parameter that is invalid.</param>
+        public static void ShouldThrow<T>(this Action action, string paramName) where T: ArgumentException
+        {
+            ShouldThrow<T>(new Assert.ThrowsDelegate(action), paramName);
+        }
+
+
         /// <summary>Verifies that the <paramref name="@delegate"/> throws the specified exception type.</summary>
         /// <typeparam name="T">The type of exception expected to be thrown.</typeparam>
         /// <param name="delegate">A <see cref="Assert.ThrowsDelegate"/> which represents the action which should throw the exception.</param>
         public static void ShouldThrow<T>(this Assert.ThrowsDelegate @delegate) where T : Exception
         {
             Assert.Throws<T>(@delegate);
+        }
+
+        /// <summary>
+        /// Verifies that the <paramref name="@delegate"/> throws an <see cref="ArgumentException"/> with a <paramref name="paramName"/> that matches <see cref="ArgumentException.ParamName"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the <see cref="ArgumentException"/> expected to be thrown.</typeparam>
+        /// <param name="delegate">A <see cref="Assert.ThrowsDelegate"/> which represents the action which should throw the exception.</param>
+        /// <param name="paramName">The name of the parameter that is invalid.</param>
+        public static void ShouldThrow<T>(this Assert.ThrowsDelegate @delegate, string paramName) where T : ArgumentException
+        {
+            var argumentException = Assert.Throws<T>(@delegate);
+            Assert.Equal(paramName, argumentException.ParamName);
         }
     }
 }


### PR DESCRIPTION
I thought this might be a handy feature.
It will allow you to prove that an ArgumentException came from the parameter you think it should come from.